### PR TITLE
Fix CVE-2020-15400: Implement HMAC-signed CSRF tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v2.10.24.3 (Unreleased)
 
+### Security Fixes
+
+- **CVE-2020-15400**: Fix CSRF token fixation vulnerability by implementing HMAC-signed tokens
+  - Tokens are now cryptographically signed with the application's Security.salt
+  - Prevents attackers from fixating tokens through XSS or physical access
+  - Maintains backward compatibility with existing legacy tokens
+
 ### Breaking Changes
 
 - Remove Xcache cache engine support (Xcache is not compatible with PHP 7.0+)

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ The following security vulnerabilities have been reported in the original CakePH
 | CVE | Description | Status in this Fork |
 |-----|-------------|-------------------|
 | [CVE-2015-8379](https://nvd.nist.gov/vuln/detail/CVE-2015-8379) | CSRF protection bypass via _method parameter | ✅ Fixed in [c0fb45e](https://github.com/friendsofcake2/cakephp/commit/c0fb45e79) (*) |
-| [CVE-2020-15400](https://nvd.nist.gov/vuln/detail/CVE-2020-15400) | CSRF token fixation (exploitable with XSS) | ❌ Not yet fixed |
+| [CVE-2020-15400](https://nvd.nist.gov/vuln/detail/CVE-2020-15400) | CSRF token fixation (exploitable with XSS) | ✅ Fixed - HMAC-signed tokens implemented |
 
-> [!WARNING]
+> [!NOTE]
 > - **CVE-2015-8379**: The fix has been applied, but additional tests from [original commit](https://github.com/cakephp/cakephp/commit/0f818a23a876c01429196bf7623e1e94a50230f0) should be added.
-> - **CVE-2020-15400**: Requires HMAC-signed CSRF tokens to prevent token fixation attacks. This fix needs to be backported from [CakePHP 4.x PR #14431](https://github.com/cakephp/cakephp/pull/14431) and [CakePHP 3.x PR #16481](https://github.com/cakephp/cakephp/pull/16481).
+> - **CVE-2020-15400**: Fixed by implementing HMAC-signed CSRF tokens that are cryptographically bound to the application. Tokens are now signed with the application's Security.salt, preventing token fixation attacks while maintaining backward compatibility with existing tokens.
 
 ## Migration Guide
 


### PR DESCRIPTION
Addresses CSRF token fixation vulnerability by implementing cryptographically signed tokens that are bound to the application, compatible with CakePHP 3.x/4.x.

Changes:
- Add HMAC signature to newly generated CSRF tokens using SHA-1
- Tokens now use base64 encoding: 16 bytes random value + 20 bytes HMAC
- HMAC is computed using application's Security.salt as the key
- Add validation of HMAC signature to prevent token tampering
- Maintain backward compatibility with existing unsigned tokens
- Use hash_equals() for constant-time comparison (always available in PHP 8.0+)
- Add TOKEN_VALUE_LENGTH constant (16 bytes) for consistency with CakePHP 4.x

Security Impact:
- Prevents attackers from fixating CSRF tokens via XSS or physical access
- Tokens are cryptographically bound to the specific application
- Existing applications continue to work with their current tokens
- Compatible with CakePHP 3.x/4.x token format

Tests:
- Add tests for HMAC token generation and validation
- Add tests for backward compatibility with legacy tokens
- Add tests to ensure modified tokens are rejected
- Add tests to prevent token fixation attacks