### PR TITLE
Add comprehensive test coverage for CVE-2015-8379 CSRF bypass prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
   - Prevents attackers from fixating tokens through XSS or physical access
   - Maintains backward compatibility with existing legacy tokens
 
+### Security Enhancements
+
+- **CVE-2015-8379**: Added comprehensive test coverage for CSRF protection bypass prevention ([PR #6](https://github.com/friendsofcake2/cakephp/pull/6))
+  - Tests for `_method` parameter override handling
+  - Tests for custom/invalid HTTP methods requiring CSRF validation
+  - Tests confirming safe methods (GET, HEAD, OPTIONS) are exempt
+  - Validates that all non-safe methods require CSRF tokens
+
 ### Breaking Changes
 
 - Remove Xcache cache engine support (Xcache is not compatible with PHP 7.0+)

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ The following security vulnerabilities have been reported in the original CakePH
 
 | CVE | Description | Status in this Fork |
 |-----|-------------|-------------------|
-| [CVE-2015-8379](https://nvd.nist.gov/vuln/detail/CVE-2015-8379) | CSRF protection bypass via _method parameter | ✅ Fixed in [c0fb45e](https://github.com/friendsofcake2/cakephp/commit/c0fb45e79) (*) |
+| [CVE-2015-8379](https://nvd.nist.gov/vuln/detail/CVE-2015-8379) | CSRF protection bypass via _method parameter | ✅ Fixed in [c0fb45e](https://github.com/friendsofcake2/cakephp/commit/c0fb45e79), tests in [PR #6](https://github.com/friendsofcake2/cakephp/pull/6) |
 | [CVE-2020-15400](https://nvd.nist.gov/vuln/detail/CVE-2020-15400) | CSRF token fixation (exploitable with XSS) | ✅ Fixed in [PR #5](https://github.com/friendsofcake2/cakephp/pull/5) |
 
 > [!NOTE]
-> - **CVE-2015-8379**: The fix has been applied, but additional tests from [original commit](https://github.com/cakephp/cakephp/commit/0f818a23a876c01429196bf7623e1e94a50230f0) should be added.
+> - **CVE-2015-8379**: The fix has been fully applied with comprehensive test coverage for `_method` parameter handling and custom HTTP methods.
 > - **CVE-2020-15400**: Fixed by implementing HMAC-signed CSRF tokens that are cryptographically bound to the application. Tokens are now signed with the application's Security.salt, preventing token fixation attacks while maintaining backward compatibility with existing tokens.
 
 ## Migration Guide


### PR DESCRIPTION
## Summary

This PR adds comprehensive test coverage to verify that CVE-2015-8379 (CSRF bypass via `_method` parameter) is properly prevented in the CakePHP 2.x framework.

## Background

CVE-2015-8379 is a vulnerability where attackers could bypass CSRF protection by using the `_method` parameter to override the HTTP method from POST to GET, causing the framework to treat malicious POST requests as safe GET requests and skip CSRF validation.

## Changes

### Test Coverage Added

- **Main vulnerability test**: Verifies that POST requests with `_method=GET` cannot bypass CSRF protection
- **Safe method tests**: Tests for HEAD and OPTIONS methods to ensure data is properly cleared
- **Unsafe method tests**: Confirms PUT, PATCH, DELETE always require CSRF tokens
- **Custom/invalid method tests**: Ensures non-standard HTTP methods require CSRF validation
- **Data presence validation**: Tests that any request with data triggers CSRF checks
- **Method override processing**: Validates the `_method` parameter processing flow

### Test Methods

- `testMethodOverrideCannotBypassCsrf` - Main test demonstrating the vulnerability is fixed
- `testPostWithMethodHeadClearsData` - Tests HEAD method override clears data
- `testPostWithMethodOptionsClearsData` - Tests OPTIONS method override clears data
- `testDataPresenceTriggersCsrfCheck` - Validates data presence detection
- `testSafeMethodsWithoutDataAllowed` - Confirms safe methods without data are allowed
- `testUnsafeMethodsAlwaysRequireCsrf` - Tests unsafe methods always need CSRF
- `testMethodOverrideWithValidToken` - Tests legitimate method override with token
- `testCustomMethodsRequireCsrf` - Tests custom HTTP methods require CSRF
- `testPostWithInvalidMethodStillRequiresCsrf` - Tests invalid methods require CSRF
- `testMethodOverrideProcessing` - Tests the `_method` processing flow

## Technical Details

The vulnerability occurs when:
1. A POST request contains `_method=GET` in the data
2. `CakeRequest` processes this and changes `REQUEST_METHOD` to GET
3. For safe methods (GET/HEAD/OPTIONS), the data array is cleared
4. Without proper validation, the request appears as a safe GET with no data

The fix ensures that `SecurityComponent` properly detects:
- Any request that originally had data requires CSRF validation
- All unsafe HTTP methods require CSRF tokens regardless of data presence
- Custom or invalid HTTP methods are treated as unsafe

## Documentation Updates

- Updated CHANGELOG.md with test coverage information
- Added references to PR #6 in README.md

## Testing

All tests pass across supported PHP versions (8.0, 8.1, 8.2, 8.3, 8.4) and databases.

## References

- Original vulnerability: [CVE-2015-8379](https://nvd.nist.gov/vuln/detail/CVE-2015-8379)
- Original fix commit: [c0fb45e](https://github.com/friendsofcake2/cakephp/commit/c0fb45e79)
- CakePHP 3.x reference: [0f818a2](https://github.com/cakephp/cakephp/commit/0f818a23a876c01429196bf7623e1e94a50230f0)