### PR TITLE
Fix mail function arguments for PHP 8.0+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## Unreleased
 
+### PHP 8.0+ Compatibility
+
+- **Mail Function Compatibility**: Updated mail transport for PHP 8.0+ strict typing ([PR #10](https://github.com/friendsofcake2/cakephp/pull/10))
+  - Changed `mail()` function parameter defaults from `null` to empty string
+  - Added strict type declarations to `MailTransport::_mail()` method
+  - Updated method signature: `_mail(string $to, string $subject, string $message, array|string $headers = [], string $params = ''): void`
+  - Replaced `@` error suppression with `set_error_handler()` for better error handling
+  - Updated `CakeEmail::send()` default parameter from `null` to empty string
+  - Removed deprecated `safe_mode` checks (removed in PHP 7.2.0)
+  - Removed `MailTransport.php` from phpcs exclusions (now coding standards compliant)
+
 ### Database Support
 
-- **SQL Server 2022 Support**: Added comprehensive SQL Server 2022 support for testing and development
+- **SQL Server 2022 Support**: Added comprehensive SQL Server 2022 support for testing and development ([PR #9](https://github.com/friendsofcake2/cakephp/pull/9))
   - **Docker Infrastructure**:
     - Added SQL Server 2022 container to docker-compose.yml with automatic database initialization
     - Created custom entrypoint script for automatic database and schema creation (cakephp_test with schemas: dbo, test2, test3)

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1237,7 +1237,7 @@ class CakeEmail
      * @return array
      * @throws SocketException
      */
-    public function send($content = null)
+    public function send($content = '')
     {
         if (empty($this->_from)) {
             throw new SocketException(__d('cake_dev', 'From is not specified.'));

--- a/lib/Cake/Network/Email/MailTransport.php
+++ b/lib/Cake/Network/Email/MailTransport.php
@@ -35,10 +35,7 @@ class MailTransport extends AbstractTransport
     {
         // https://github.com/cakephp/cakephp/issues/2209
         // https://bugs.php.net/bug.php?id=47983
-        $eol = "\r\n";
-        if (isset($this->_config['eol'])) {
-            $eol = $this->_config['eol'];
-        }
+        $eol = $this->_config['eol'] ?? "\r\n";
         $headers = $email->getHeaders(['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc']);
         $to = $headers['To'];
         unset($headers['To']);
@@ -51,7 +48,7 @@ class MailTransport extends AbstractTransport
 
         $message = implode($eol, $email->message());
 
-        $params = $this->_config['additionalParameters'] ?? null;
+        $params = $this->_config['additionalParameters'] ?? '';
         $this->_mail($to, $subject, $message, $headers, $params);
 
         $headers .= $eol . 'Subject: ' . $subject;
@@ -66,24 +63,30 @@ class MailTransport extends AbstractTransport
      * @param string $to email's recipient
      * @param string $subject email's subject
      * @param string $message email's body
-     * @param string $headers email's custom headers
-     * @param string $params additional params for sending email, will be ignored when in safe_mode
+     * @param array|string $headers email's custom headers
+     * @param string $params additional params for sending email
      * @throws SocketException if mail could not be sent
      * @return void
      */
-    protected function _mail($to, $subject, $message, $headers, $params = null)
+    protected function _mail(string $to, string $subject, string $message, array|string $headers = [], string $params = ''): void
     {
-        if (ini_get('safe_mode')) {
-            //@codingStandardsIgnoreStart
-            if (!@mail($to, $subject, $message, $headers)) {
-                $error = error_get_last();
-                $msg = 'Could not send email: ' . ($error['message'] ?? 'unknown');
-                throw new SocketException($msg);
-            }
-        } elseif (!@mail($to, $subject, $message, $headers, $params)) {
-            $error = error_get_last();
-            $msg = 'Could not send email: ' . ($error['message'] ?? 'unknown');
-            //@codingStandardsIgnoreEnd
+        $errors = [];
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$errors) {
+            $errors[] = [
+                'level' => $errno,
+                'message' => $errstr,
+                'file' => $errfile,
+                'line' => $errline
+            ];
+            return true;
+        });
+        $result = mail($to, $subject, $message, $headers, $params);
+        restore_error_handler();
+
+        if (!$result) {
+            $lastError = !empty($errors) ? end($errors) : null;
+            $msg = 'Could not send email: ' . ($lastError['message'] ?? 'unknown');
+
             throw new SocketException($msg);
         }
     }

--- a/lib/Cake/Network/Email/MailTransport.php
+++ b/lib/Cake/Network/Email/MailTransport.php
@@ -76,8 +76,9 @@ class MailTransport extends AbstractTransport
                 'level' => $errno,
                 'message' => $errstr,
                 'file' => $errfile,
-                'line' => $errline
+                'line' => $errline,
             ];
+
             return true;
         });
         $result = mail($to, $subject, $message, $headers, $params);

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -80,8 +80,6 @@ class BasicsTest extends CakeTestCase
      */
     public function testEnv()
     {
-        $this->skipIf(!function_exists('ini_get') || ini_get('safe_mode') === '1', 'Safe mode is on.');
-
         $server = $_SERVER;
         $env = $_ENV;
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -122,7 +122,6 @@
         <exclude-pattern>lib/Cake/Console/Command/ConsoleShell.php</exclude-pattern>
         <exclude-pattern>lib/Cake/Console/Shell.php</exclude-pattern>
         <exclude-pattern>lib/Cake/Network/CakeResponse.php</exclude-pattern>
-        <exclude-pattern>lib/Cake/Network/Email/MailTransport.php</exclude-pattern>
         <exclude-pattern>lib/Cake/Test/Case/Cache/CacheTest.php</exclude-pattern>
         <exclude-pattern>lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php</exclude-pattern>
         <exclude-pattern>lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php</exclude-pattern>


### PR DESCRIPTION
## Summary

This PR updates the `MailTransport` class to be fully compatible with PHP 8.0+ strict typing requirements for the `mail()` function, and removes deprecated `safe_mode` checks.

## Changes

### Mail Function Parameter Updates

**MailTransport.php:**
- Changed `$params` default from `null` to `''` (empty string)
- Updated `_mail()` method signature with strict type declarations:
  ```php
  protected function _mail(
      string $to,
      string $subject,
      string $message,
      array|string $headers = [],
      string $params = ''
  ): void
  ```
- Replaced `@` error suppression operator with `set_error_handler()` for cleaner error handling
- Removed deprecated `safe_mode` checks (removed in PHP 7.2.0)

**CakeEmail.php:**
- Changed `send()` method default parameter from `null` to `''` (empty string)

**BasicsTest.php:**
- Removed `safe_mode` check from `testEnv()`

### Code Quality

**phpcs.xml:**
- Removed `MailTransport.php` from phpcs exclusions (now coding standards compliant)

## Why These Changes?

1. **PHP 8.0+ Compatibility**: The `mail()` function in PHP 8.0+ has strict type declarations requiring strings, not nullable types
2. **Deprecated Feature Removal**: `safe_mode` was removed in PHP 7.2.0 and should no longer be checked
3. **Better Error Handling**: Using `set_error_handler()` instead of `@` operator provides better error tracking
4. **Type Safety**: Explicit type declarations improve code reliability and IDE support

## Testing

- ✅ All existing tests pass
- ✅ Mail transport functionality remains unchanged
- ✅ Compatible with PHP 8.0, 8.1, 8.2, 8.3, 8.4

## Breaking Changes

None. This is a backward-compatible change that only affects internal implementation.

## Related Issues

Fixes compatibility issues with PHP 8.0+ strict typing for `mail()` function parameters.
